### PR TITLE
Update Vanilla Registry Documentation

### DIFF
--- a/docs/groovy-script/getting_started/classes.md
+++ b/docs/groovy-script/getting_started/classes.md
@@ -29,24 +29,32 @@ The default package classes are located in is `classes`, so you would run `impor
 
 ## Example
 
-::: info Basic Example {id="example"}
+:::: info Basic Example {id="example"}
 
-With this file, named `DemoClass.groovy`, placed inside the `classes` folder, and the folder being added to the `classes` element in `runConfig.json`:
+With a named `DemoClass.groovy` that is registered by the `runConfig.json` to the `classes` element,
+you can access that class from any script file or another class.
 
-```groovy
+::: code-group
+
+```groovy [classes/DemoClass.groovy]
 class DemoClass {
     final static def iron = item 'minecraft:iron_ingot'
     final static def gold = item 'minecraft:gold_ingot'
 }
 ```
 
-You are able to import and use it in other script files:
-
-```groovy
-import classes.DemoClass
-
-log.info DemoClass.iron in ore('ingotIron')
+```json [runConfig.json]
+"classes": [
+  "classes/" // targets either the file or a folder that the file is nested within
+]
 ```
 
+```groovy [postInit/CheckIron.groovy]
+import classes.DemoClass
+
+log.info(DemoClass.iron in ore('ingotIron'))
+```
 
 :::
+
+::::

--- a/docs/groovy-script/getting_started/editors.md
+++ b/docs/groovy-script/getting_started/editors.md
@@ -90,8 +90,9 @@ This language support will work with any variation of Emacs, but will presume yo
 
 1. Open Emacs and install [lsp-mode](https://emacs-lsp.github.io/lsp-mode/page/installation/), and follow further installation instructions for lsp-mode.
 2. Install the GroovyScript LSP file here:
-::: details GroovyScript LSP {id="example"}
-```lisp title="lsp-groovyscript.el"
+:::: details GroovyScript LSP {id="example"}
+::: code-group
+```lisp [lsp-groovyscript.el]
 ;;; lsp-groovyscript.el --- GroovyScript LSP support for lsp-mode -*- lexical-binding: t; -*-
 
 ;; Version: 1.0.0
@@ -143,6 +144,7 @@ This language support will work with any variation of Emacs, but will presume yo
 ;;; lsp-groovyscript.el ends here
 ```
 :::
+::::
 3. [Start the Language Server](#start-the-language-server) via the instructions above
 4. The port in the `groovyscript.cfg` config file must match the port setting.
 5. Done

--- a/docs/groovy-script/getting_started/groovy_modifications.md
+++ b/docs/groovy-script/getting_started/groovy_modifications.md
@@ -60,14 +60,17 @@ import static net.minecraft.util.math.MathHelper.*
 ## Maps
 
 
-GroovyScript replaces the use of `LinkedHashMap` with uses `Object2ObjectLinkedOpenHashMap` as the default map used in Groovy.
-This is done because it is slightly more memory efficient and keeps the element order.
+GroovyScript replaces uses of `LinkedHashMap` with `Object2ObjectLinkedOpenHashMap` as the default map used in Groovy.
+This is done because it is slightly more memory efficient while still keeping the element order.
 
+If you want to create a `LinkedHashMap` anyways, you can simply import it and create a new instance of it as normal.
+This only changes the shorthand method of creating maps (`[:]`).
 
 
 ## Security Restrictions
 
 
-A number of packages or classes are banned, and not able to be used by Groovy.
+A number of packages, classes, and methods are banned, and not able to be used by Groovy.
 
-When interacting with a File object through Groovy, the File can only refer to a file path that targets inside the minecraft directory.
+In particular, when interacting with a File object through Groovy,
+the File can only refer to a file path that targets inside the minecraft directory.

--- a/docs/groovy-script/getting_started/reloading.md
+++ b/docs/groovy-script/getting_started/reloading.md
@@ -43,8 +43,10 @@ However, you can add your own custom class and implement reloading for your reci
 To do so, first make a new file in `classes` with the class containing an `add`, `remove`, and an `onReload` method.
 It should have an instance created inside it for access purposes.
 
-::: info DemoRegistry {id="example"}
-```groovy
+:::: info Example {id="example"}
+::: code-group {id="example"}
+
+```groovy [classes/DemoRegistry.groovy]
 import example.DemoHolder
 import example.DemoRecipe
 
@@ -74,11 +76,14 @@ class DemoRegistry {
 }
 ```
 :::
+::::
 
 Then, add an event listener that is listening for `GroovyReloadEvent`.
 Inside of this event listener, call the `onReload` method.
 
-```groovy
+::: code-group
+
+```groovy [postInit/ReloadHelper.groovy]
 import classes.DemoRegistry
 import com.cleanroommc.groovyscript.event.GroovyReloadEvent
 
@@ -86,6 +91,8 @@ eventManager.listen(GroovyReloadEvent) {
     DemoRegistry.instance.onReload()
 }
 ```
+
+:::
 
 Finally, any time you would add a recipe to or remove a recipe from `DemoHolder.DemoRecipeList`,
 ensure it is manipulated via `DemoRegistry.instance`.

--- a/docs/groovy-script/getting_started/run_config.md
+++ b/docs/groovy-script/getting_started/run_config.md
@@ -13,8 +13,9 @@ Scripts with stuff like Item Creation go in `groovy/preInit`.
 
 Let's see what the file can look like.
 
-::: info Example {id="example"}
-```json
+:::: info Example {id="example"}
+::: code-group
+```json [groovy/runConfig.json]
 {
   "packName": "",
   "packId": "",
@@ -42,6 +43,7 @@ Let's see what the file can look like.
 }
 ```
 :::
+::::
 
 Let's go through it bit by bit:
 

--- a/docs/groovy-script/groovy/differences_from_java.md
+++ b/docs/groovy-script/groovy/differences_from_java.md
@@ -38,9 +38,9 @@ Parentheses around parameters are optional when there is no ambiguity.
 ::: code-group
 
 ```java
-Code.run('example');
-Code.run(Code.nested('example'));
-println('hello');
+Code.run("example");
+Code.run(Code.nested("example"));
+System.out.println("hello");
 ```
 
 ```groovy
@@ -105,7 +105,7 @@ In Groovy, you can easily create a list using square braces `[]`, using commas `
 ::: code-group
 
 ```java
-List<Integer> list = new ArrayList<>();
+List<String> list = new ArrayList<>();
 list.add("example");
 list.add("demo");
 ```
@@ -131,7 +131,11 @@ map.put(3, "demo");
 ```
 
 ```groovy
-def map = [1: "example", 3: "demo"]
+def map0 = [:]
+map0[1] = "example"
+map0[3] = "demo"
+def map1 = [1: "example", 3: "demo"]     // shorthand
+def map2 = [(1): "example", (3): "demo"] // if the key is an expression, wrapping it in parentheses may be needed
 ```
 
 :::
@@ -166,6 +170,7 @@ If the field is final, only a *getter* method will be created.
 
 ```java
 public class DemoClass {
+    private final String internal = "internal";
     private final String value = "value";
     private String name = "example";
 
@@ -185,8 +190,9 @@ public class DemoClass {
 
 ```groovy
 class DemoClass {
-    final def value = "value"
-    def name = "example"
+    private final def internal = 'internal'
+    final def value = 'value'
+    def name = 'example'
 }
 ```
 
@@ -244,7 +250,7 @@ public class DemoClass {
 
 ```groovy
 class DemoClass {
-    DemoClass foo() {
+    def foo() {
         this
     }
 
@@ -334,9 +340,9 @@ Groovy has multiple ways of simplifying interacting with multiple methods or fie
 DemoClass obj = new DemoClass();
 obj.sayHi();
 obj.value = 1;
-obj.name = 'hello';
+obj.name = "hello";
 obj.total = 100;
-obj.clay = 'clay';
+obj.clay = "clay";
 obj.current = 5;
 obj.sayGoodbye();
 ```

--- a/docs/groovy-script/groovy/loops.md
+++ b/docs/groovy-script/groovy/loops.md
@@ -90,3 +90,60 @@ for (entry in elements) {
 
 `break` can be used at any time inside a loop to abort the current and all following runs.
 `continue` will only abort the current run and _continues_ with the next run (if the condition is still true)
+
+
+## Count
+
+There are multiple different strategies to iterate through a loop a specific number of times.
+
+::: code-group
+
+
+```groovy:no-line-numbers [while]
+def x = 0
+while (x < 10) {
+    log.info x++
+}
+```
+
+```groovy:no-line-numbers [do-while]
+def x = 0
+do {
+    log.info x++ // this would execute at least once, even if x was greater than 10
+} while (x < 10)
+```
+
+```groovy:no-line-numbers [for]
+for (def x = 0; x < 10; x++) {
+    log.info x
+}
+```
+
+```groovy:no-line-numbers [enhanced list]
+for (def x in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+    log.info x
+}
+for (def x : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) { // "in" and ":" are the same here
+    log.info x
+}
+```
+
+```groovy:no-line-numbers [each list]
+[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].each {
+    log.info x
+}
+```
+
+```groovy:no-line-numbers [for in range]
+for (def x : 0..<10) { // creates a range
+    log.info x
+}
+```
+
+```groovy:no-line-numbers [each range]
+(0..<10).each {
+    log.info x
+}
+```
+
+:::

--- a/docs/groovy-script/groovy/maps.md
+++ b/docs/groovy-script/groovy/maps.md
@@ -34,7 +34,7 @@ We are using the map we created above here.
 ```groovy:no-line-numbers
 println(elements['Pb']) // Lead
 println(elements['Ag']) // Silver
-println(elements['B']) // null since there is no key 'B'
+println(elements['B'])  // null since there is no key 'B'
 ```
 
 ## Modifying maps
@@ -42,6 +42,29 @@ println(elements['B']) // null since there is no key 'B'
 We are using the map we created above here.
 
 ```groovy:no-line-numbers
-elements['Au'] = 'Copper' // Au is know mapped to copper
-elements.remove('H') // removes H: Hydrogen
+elements['Au'] = 'Copper' // Au is now mapped to copper
+elements.remove('H')      // removes H: Hydrogen
 ```
+
+## Variable keys
+
+Groovy can have the keys of a map be set via variables.
+However, in order to do this, the key might need to be surrounded in parentheses
+to be properly handled.
+
+This is particularly relevant with GroovyScript [Object Mappers](../getting_started/object_mappers.md).
+
+```groovy:no-line-numbers
+def itemStackToValue = [
+    (item('minecraft:dirt')): -1,
+    (item('minecraft:stone')): 5,
+    (item('minecraft:clay')): 1000,
+]
+```
+
+::: info Warning {id="danger"}
+
+Failing to properly surround a key in parentheses if it requires them may result in the script file
+throwing a `MultipleCompilationErrorsException` due to being "unable to resolve class".
+
+:::

--- a/docs/groovy-script/minecraft/helpers/command.md
+++ b/docs/groovy-script/minecraft/helpers/command.md
@@ -1,0 +1,87 @@
+---
+title: "Custom Commands"
+titleTemplate: "Minecraft | CleanroomMC"
+description: "Create custom commands, either generally or specifically for the client."
+source_code_link: "https://github.com/CleanroomMC/GroovyScript/blob/master/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/Command.java"
+---
+
+# Custom Commands (Minecraft)
+
+## Description
+
+Create custom commands, either generally or specifically for the client.
+
+## Identifier
+
+Refer to this via any of the following:
+
+```groovy:no-line-numbers {1}
+command/* Used as page default */ // [!code focus]
+Command
+minecraft.command
+minecraft.Command
+Minecraft.command
+Minecraft.Command
+vanilla.command
+vanilla.Command
+Vanilla.command
+Vanilla.Command
+mods.mc.command
+mods.mc.Command
+mods.vanilla.command
+mods.vanilla.Command
+mods.minecraft.command
+mods.minecraft.Command
+```
+
+
+## Adding Entries
+
+- Registers the given command to the client:
+
+    ```groovy:no-line-numbers
+    command.registerClientCommand(ICommand)
+    ```
+
+- Registers the given command to the client in the format `name`, `command`, with `command` being a Closure taking 3 parameters, `MinecraftServer server`, `ICommandSender sender`, and `String... args`:
+
+    ```groovy:no-line-numbers
+    command.registerClientCommand(String, SimpleCommand.ICommand)
+    ```
+
+- Registers the given command to the client in the format `name`, `usage`, `command`, with `command` being a Closure taking 3 parameters, `MinecraftServer server`, `ICommandSender sender`, and `String... args`:
+
+    ```groovy:no-line-numbers
+    command.registerClientCommand(String, String, SimpleCommand.ICommand)
+    ```
+
+- Registers the given command to the given command handler, in the format `handler`, `command`:
+
+    ```groovy:no-line-numbers
+    command.registerCommand(CommandHandler, ICommand)
+    ```
+
+- Registers the given command:
+
+    ```groovy:no-line-numbers
+    command.registerCommand(ICommand)
+    ```
+
+- Registers the given command in the format `name`, `command`, with `command` being a Closure taking 3 parameters, `MinecraftServer server`, `ICommandSender sender`, and `String... args`:
+
+    ```groovy:no-line-numbers
+    command.registerCommand(String, SimpleCommand.ICommand)
+    ```
+
+- Registers the given command in the format `name`, `usage`, `command`, with `command` being a Closure taking 3 parameters, `MinecraftServer server`, `ICommandSender sender`, and `String... args`:
+
+    ```groovy:no-line-numbers
+    command.registerCommand(String, String, SimpleCommand.ICommand)
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+command.registerCommand('groovy_test', { server, sender, args -> sender.sendMessage('Hello from GroovyScript')})
+```
+
+::::::::::

--- a/docs/groovy-script/minecraft/helpers/crafting.md
+++ b/docs/groovy-script/minecraft/helpers/crafting.md
@@ -15,12 +15,12 @@ A normal crafting recipe that takes place in the Vanilla Crafting Table, convert
 While shorthand methods to create recipes have been supplied, it is far easier to use the recipe builder.
 ::::::::::
 
-:::::::::: details Tip {open id="tip"}
-You can view recipe names in JEI/HEI by hovering over the output with `F3+h` mode enabled.
-::::::::::
-
 :::::::::: details Note {open id="note"}
 Fallback keys are global and apply to all classes using the matrix feature of `AbstractCraftingRecipeBuilder`.
+::::::::::
+
+:::::::::: details Tip {open id="tip"}
+You can view recipe names in JEI/HEI by hovering over the output with `F3+h` mode enabled.
 ::::::::::
 
 ## Identifier
@@ -30,6 +30,20 @@ Refer to this via any of the following:
 ```groovy:no-line-numbers {1}
 crafting/* Used as page default */ // [!code focus]
 Crafting
+minecraft.crafting
+minecraft.Crafting
+Minecraft.crafting
+Minecraft.Crafting
+vanilla.crafting
+vanilla.Crafting
+Vanilla.crafting
+Vanilla.Crafting
+mods.mc.crafting
+mods.mc.Crafting
+mods.vanilla.crafting
+mods.vanilla.Crafting
+mods.minecraft.crafting
+mods.minecraft.Crafting
 ```
 
 
@@ -50,6 +64,12 @@ Crafting
 
 ## Adding Recipes
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    crafting.add(IRecipe)
+    ```
+
 - Adds a shaped recipe in the format `output`, `input`:
 
     ```groovy:no-line-numbers
@@ -68,55 +88,55 @@ Crafting
     crafting.addShaped(String, ItemStack, List<List<IIngredient>>)
     ```
 
-- Adds a shapeless in the format `output`, `input`:
+- Adds a shapeless recipe in the format `output`, `input`:
 
     ```groovy:no-line-numbers
     crafting.addShapeless(ItemStack, List<IIngredient>)
     ```
 
-- Adds a shapeless in the format `name`, `output`, `input`:
+- Adds a shapeless recipe in the format `name`, `output`, `input`:
 
     ```groovy:no-line-numbers
     crafting.addShapeless(ResourceLocation, ItemStack, List<IIngredient>)
     ```
 
-- Adds a shapeless in the format `name`, `output`, `input`:
+- Adds a shapeless recipe in the format `name`, `output`, `input`:
 
     ```groovy:no-line-numbers
     crafting.addShapeless(String, ItemStack, List<IIngredient>)
     ```
 
-- Adds a shaped in the format `output`, `input` and removes the recipe matching the given output:
+- Adds a shaped recipe in the format `output`, `input` and removes the recipe matching the given output:
 
     ```groovy:no-line-numbers
     crafting.replaceShaped(ItemStack, List<List<IIngredient>>)
     ```
 
-- Adds a shaped in the format `name`, `output`, `input` and removes the recipe matching the given name:
+- Adds a shaped recipe in the format `name`, `output`, `input` and removes the recipe matching the given name:
 
     ```groovy:no-line-numbers
     crafting.replaceShaped(ResourceLocation, ItemStack, List<List<IIngredient>>)
     ```
 
-- Adds a shaped in the format `name`, `output`, `input` and removes the recipe matching the given name:
+- Adds a shaped recipe in the format `name`, `output`, `input` and removes the recipe matching the given name:
 
     ```groovy:no-line-numbers
     crafting.replaceShaped(String, ItemStack, List<List<IIngredient>>)
     ```
 
-- Adds a shapeless in the format `output`, `input` and removes the recipe matching the given output:
+- Adds a shapeless recipe in the format `output`, `input` and removes the recipe matching the given output:
 
     ```groovy:no-line-numbers
     crafting.replaceShapeless(ItemStack, List<IIngredient>)
     ```
 
-- Adds a shapeless in the format `name`, `output`, `input` and removes the recipe matching the given name:
+- Adds a shapeless recipe in the format `name`, `output`, `input` and removes the recipe matching the given name:
 
     ```groovy:no-line-numbers
     crafting.replaceShapeless(ResourceLocation, ItemStack, List<IIngredient>)
     ```
 
-- Adds a shapeless in the format `name`, `output`, `input` and removes the recipe matching the given name:
+- Adds a shapeless recipe in the format `name`, `output`, `input` and removes the recipe matching the given name:
 
     ```groovy:no-line-numbers
     crafting.replaceShapeless(String, ItemStack, List<IIngredient>)
@@ -404,6 +424,24 @@ crafting.shapelessBuilder()
 
 ## Removing Recipes
 
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    crafting.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    crafting.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    crafting.remove(IRecipe)
+    ```
+
 - Removes all recipes that match the given input:
 
     ```groovy:no-line-numbers
@@ -425,6 +463,8 @@ crafting.shapelessBuilder()
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 crafting.removeByOutput(item('minecraft:gold_ingot'))
+crafting.remove('minecraft:mossy_stonebrick')
+crafting.remove(resource('minecraft:stonebrick'))
 crafting.removeAll()
 ```
 

--- a/docs/groovy-script/minecraft/helpers/furnace.md
+++ b/docs/groovy-script/minecraft/helpers/furnace.md
@@ -18,6 +18,20 @@ Refer to this via any of the following:
 ```groovy:no-line-numbers {1}
 furnace/* Used as page default */ // [!code focus]
 Furnace
+minecraft.furnace
+minecraft.Furnace
+Minecraft.furnace
+Minecraft.Furnace
+vanilla.furnace
+vanilla.Furnace
+Vanilla.furnace
+Vanilla.Furnace
+mods.mc.furnace
+mods.mc.Furnace
+mods.vanilla.furnace
+mods.vanilla.Furnace
+mods.minecraft.furnace
+mods.minecraft.Furnace
 ```
 
 
@@ -50,6 +64,22 @@ Just like other recipe types, the Furnace also uses a recipe builder.
 Don't know what a builder is? Check [the builder info page](../../getting_started/builder.md) out.
 
 :::::::::: details furnace.recipeBuilder() {open id="abstract"}
+- `IngredientList<IIngredient>`. Sets the item inputs of the recipe. Requires exactly 1.
+
+    ```groovy:no-line-numbers
+    input(IIngredient)
+    input(IIngredient...)
+    input(Collection<IIngredient>)
+    ```
+
+- `ItemStackList`. Sets the item outputs of the recipe. Requires exactly 1.
+
+    ```groovy:no-line-numbers
+    output(ItemStack)
+    output(ItemStack...)
+    output(Collection<ItemStack>)
+    ```
+
 - `float`. Sets the experience rewarded for smelting the given input. Requires greater than or equal to 0. (Default `0.0f`).
 
     ```groovy:no-line-numbers

--- a/docs/groovy-script/minecraft/helpers/game_rule.md
+++ b/docs/groovy-script/minecraft/helpers/game_rule.md
@@ -1,0 +1,93 @@
+---
+title: "Default GameRules"
+titleTemplate: "Minecraft | CleanroomMC"
+description: "Create or assign a default value to GameRules."
+source_code_link: "https://github.com/CleanroomMC/GroovyScript/blob/master/src/main/java/com/cleanroommc/groovyscript/compat/vanilla/GameRule.java"
+---
+
+# Default GameRules (Minecraft)
+
+## Description
+
+Create or assign a default value to GameRules.
+
+:::::::::: details Warning {open id="warning"}
+GameRules are case-sensitive! Enable logging of new GameRules via `setWarnNewGameRule` to ensure you are modifying an existing GameRule and not creating a new and unused one!
+::::::::::
+
+## Identifier
+
+Refer to this via any of the following:
+
+```groovy:no-line-numbers {2}
+gamerule
+game_rule/* Used as page default */ // [!code focus]
+gameRule
+GameRule
+minecraft.gamerule
+minecraft.game_rule
+minecraft.gameRule
+minecraft.GameRule
+Minecraft.gamerule
+Minecraft.game_rule
+Minecraft.gameRule
+Minecraft.GameRule
+vanilla.gamerule
+vanilla.game_rule
+vanilla.gameRule
+vanilla.GameRule
+Vanilla.gamerule
+Vanilla.game_rule
+Vanilla.gameRule
+Vanilla.GameRule
+mods.mc.gamerule
+mods.mc.game_rule
+mods.mc.gameRule
+mods.mc.GameRule
+mods.vanilla.gamerule
+mods.vanilla.game_rule
+mods.vanilla.gameRule
+mods.vanilla.GameRule
+mods.minecraft.gamerule
+mods.minecraft.game_rule
+mods.minecraft.gameRule
+mods.minecraft.GameRule
+```
+
+
+## Editing Values
+
+- Sets if creating new GameRules logs a warning. Enable it if you need to check spelling/capitalization. Disabled by default:
+
+    ```groovy:no-line-numbers
+    game_rule.setWarnNewGameRule(boolean)
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+game_rule.setWarnNewGameRule(true)
+```
+
+::::::::::
+
+## Adding Entries
+
+- Adds a map of GameRule name to values:
+
+    ```groovy:no-line-numbers
+    game_rule.add(Map<String, String>)
+    ```
+
+- Adds a new entry in the format `name`, `value`, with `value` being a String that can represent a number (`-1`, `5`) or boolean (`true`, `false`):
+
+    ```groovy:no-line-numbers
+    game_rule.add(String, String)
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+game_rule.add(['mobGriefing': 'false', 'keepInventory': 'true'])
+game_rule.add('doDaylightCycle', 'false')
+```
+
+::::::::::

--- a/docs/groovy-script/minecraft/helpers/index.md
+++ b/docs/groovy-script/minecraft/helpers/index.md
@@ -4,15 +4,19 @@ order: 700
 ---
 
 
-# Helpers
+# Registries
 
 ## Categories
 
-Has 5 subcategories.
+Has 7 subcategories.
+
+* [Custom Commands](./command.md)
 
 * [Crafting Table](./crafting.md)
 
 * [Furnace](./furnace.md)
+
+* [Default GameRules](./game_rule.md)
 
 * [Ore Dictionary](./ore_dict.md)
 

--- a/docs/groovy-script/minecraft/helpers/ore_dict.md
+++ b/docs/groovy-script/minecraft/helpers/ore_dict.md
@@ -24,24 +24,72 @@ ore_dictionary
 oredictionary
 oreDictionary
 OreDictionary
+minecraft.ore_dict
+minecraft.oredict
+minecraft.oreDict
+minecraft.OreDict
+minecraft.ore_dictionary
+minecraft.oredictionary
+minecraft.oreDictionary
+minecraft.OreDictionary
+Minecraft.ore_dict
+Minecraft.oredict
+Minecraft.oreDict
+Minecraft.OreDict
+Minecraft.ore_dictionary
+Minecraft.oredictionary
+Minecraft.oreDictionary
+Minecraft.OreDictionary
+vanilla.ore_dict
+vanilla.oredict
+vanilla.oreDict
+vanilla.OreDict
+vanilla.ore_dictionary
+vanilla.oredictionary
+vanilla.oreDictionary
+vanilla.OreDictionary
+Vanilla.ore_dict
+Vanilla.oredict
+Vanilla.oreDict
+Vanilla.OreDict
+Vanilla.ore_dictionary
+Vanilla.oredictionary
+Vanilla.oreDictionary
+Vanilla.OreDictionary
+mods.mc.ore_dict
+mods.mc.oredict
+mods.mc.oreDict
+mods.mc.OreDict
+mods.mc.ore_dictionary
+mods.mc.oredictionary
+mods.mc.oreDictionary
+mods.mc.OreDictionary
+mods.minecraft.ore_dict
+mods.minecraft.oredict
+mods.minecraft.oreDict
+mods.minecraft.OreDict
+mods.minecraft.ore_dictionary
+mods.minecraft.oredictionary
+mods.minecraft.oreDictionary
+mods.minecraft.OreDictionary
 ```
 
 
-## Adding Recipes
+## Adding Entries
 
-- Adds the given oredict to the given oredict:
+- Adds the given itemstack to the given oredict:
 
     ```groovy:no-line-numbers
     ore_dict.add(String, Block)
     ```
 
-- Adds the given oredict to the given oredict:
+- Adds the given itemstack to the given oredict:
 
     ```groovy:no-line-numbers
     ore_dict.add(String, Item)
     ```
 
-- Adds the given oredict to the given oredict:
+- Adds the given itemstack to the given oredict:
 
     ```groovy:no-line-numbers
     ore_dict.add(String, ItemStack)
@@ -55,18 +103,18 @@ ore_dict.add('netherStar', item('minecraft:gold_ingot'))
 
 ::::::::::
 
-## Removing Recipes
-
-- Removes the given itemstack from the given oredict:
-
-    ```groovy:no-line-numbers
-    ore_dict.remove(String, ItemStack)
-    ```
+## Removing Entries
 
 - Removes all itemstacks from the given oredict:
 
     ```groovy:no-line-numbers
     ore_dict.clear(String)
+    ```
+
+- Removes the given itemstack from the given oredict:
+
+    ```groovy:no-line-numbers
+    ore_dict.remove(String, ItemStack)
     ```
 
 - Removes all itemstacks from the given oredict:
@@ -83,15 +131,15 @@ ore_dict.add('netherStar', item('minecraft:gold_ingot'))
 
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
-ore_dict.remove('netherStar', item('minecraft:nether_star'))
 ore_dict.clear('plankWood')
+ore_dict.remove('netherStar', item('minecraft:nether_star'))
 ore_dict.removeAll('ingotIron')
 ore_dict.removeAll()
 ```
 
 ::::::::::
 
-## Getting the value of recipes
+## Getting the value of entries
 
 - Returns true if the given oredict exists, although this does not check if the oredict contains entries:
 

--- a/docs/groovy-script/minecraft/helpers/ore_dict.md
+++ b/docs/groovy-script/minecraft/helpers/ore_dict.md
@@ -69,13 +69,13 @@ ore_dict.add('netherStar', item('minecraft:gold_ingot'))
     ore_dict.clear(String)
     ```
 
-- Removes all registered recipes:
+- Removes all itemstacks from the given oredict:
 
     ```groovy:no-line-numbers
     ore_dict.removeAll(String)
     ```
 
-- Removes all registered recipes:
+- Removes all itemstacks from all oredicts:
 
     ```groovy:no-line-numbers
     ore_dict.removeAll()

--- a/docs/groovy-script/minecraft/helpers/player.md
+++ b/docs/groovy-script/minecraft/helpers/player.md
@@ -15,6 +15,10 @@ Sets the starting inventory of the player, including armor slots and offhand.
 No more than a total of 41 items can be inserted into the inventory.
 ::::::::::
 
+:::::::::: details Tip {open id="tip"}
+When testing the Starting Inventory items, use `setTestStartingItems(true)` to allow testing every time a player logs in instead of just the first.
+::::::::::
+
 ## Identifier
 
 Refer to this via any of the following:
@@ -22,31 +26,42 @@ Refer to this via any of the following:
 ```groovy:no-line-numbers {1}
 player/* Used as page default */ // [!code focus]
 Player
+minecraft.player
+minecraft.Player
+Minecraft.player
+Minecraft.Player
+vanilla.player
+vanilla.Player
+Vanilla.player
+Vanilla.Player
+mods.mc.player
+mods.mc.Player
+mods.minecraft.player
+mods.minecraft.Player
 ```
 
 
 ## Editing Values
 
-- Sets if items given when joining the world regardless of if the flag has already been set:
-
-    ```groovy:no-line-numbers
-    player.testingStartingItems
-    ```
-
 - Sets if the player inventory is cleared prior to giving the player these items:
 
     ```groovy:no-line-numbers
-    player.replaceDefaultInventory
+    mods.minecraft.player.setReplaceDefaultInventory(boolean)
+    ```
+
+- Sets if items given when joining the world regardless of if the flag has already been set:
+
+    ```groovy:no-line-numbers
+    mods.minecraft.player.setTestStartingItems(boolean)
     ```
 
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
-player.testingStartingItems = true
-player.replaceDefaultInventory = true
+mods.minecraft.player.setReplaceDefaultInventory(true)
+mods.minecraft.player.setTestStartingItems(true)
 ```
 
 ::::::::::
-
 
 ## Adding Entries
 

--- a/docs/groovy-script/minecraft/helpers/rarity.md
+++ b/docs/groovy-script/minecraft/helpers/rarity.md
@@ -22,18 +22,30 @@ Refer to this via any of the following:
 ```groovy:no-line-numbers {1}
 rarity/* Used as page default */ // [!code focus]
 Rarity
+minecraft.rarity
+minecraft.Rarity
+Minecraft.rarity
+Minecraft.Rarity
+vanilla.rarity
+vanilla.Rarity
+Vanilla.rarity
+Vanilla.Rarity
+mods.mc.rarity
+mods.mc.Rarity
+mods.minecraft.rarity
+mods.minecraft.Rarity
 ```
 
 
-## Editing Values
+## Adding Entries
 
-- Sets the color of the given itemstack in the format `color`, `item`:
+- Sets the color of the given itemstack in the format `rarity`, `item`:
 
     ```groovy:no-line-numbers
     rarity.set(IRarity, Closure<Boolean>)
     ```
 
-- Sets the color of the given itemstack in the format `color`, `item`:
+- Sets the color of the given itemstack in the format `rarity`, `item`:
 
     ```groovy:no-line-numbers
     rarity.set(IRarity, ItemStack)

--- a/docs/groovy-script/mods/aether_legacy/accessory.md
+++ b/docs/groovy-script/mods/aether_legacy/accessory.md
@@ -31,6 +31,12 @@ mods.aether.Accessory
     mods.aether_legacy.accessory.add(ItemStack, String)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.accessory.add(AetherAccessory)
+    ```
+
 
 ### Recipe Builder
 
@@ -73,6 +79,24 @@ mods.aether_legacy.accessory.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.accessory.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.accessory.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.accessory.remove(AetherAccessory)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/aether_legacy/enchanter.md
+++ b/docs/groovy-script/mods/aether_legacy/enchanter.md
@@ -31,6 +31,12 @@ mods.aether.Enchanter
     mods.aether_legacy.enchanter.add(ItemStack, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter.add(AetherEnchantment)
+    ```
+
 
 ### Recipe Builder
 
@@ -81,6 +87,24 @@ mods.aether_legacy.enchanter.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter.remove(AetherEnchantment)
+    ```
 
 - Removes all recipes that match the given output:
 

--- a/docs/groovy-script/mods/aether_legacy/enchanter_fuel.md
+++ b/docs/groovy-script/mods/aether_legacy/enchanter_fuel.md
@@ -35,6 +35,12 @@ mods.aether.EnchanterFuel
     mods.aether_legacy.enchanter_fuel.add(ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter_fuel.add(AetherEnchantmentFuel)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.aether_legacy.enchanter_fuel.add(item('minecraft:blaze_rod'), 1000)
@@ -43,6 +49,24 @@ mods.aether_legacy.enchanter_fuel.add(item('minecraft:blaze_rod'), 1000)
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter_fuel.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter_fuel.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.enchanter_fuel.remove(AetherEnchantmentFuel)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/aether_legacy/freezer.md
+++ b/docs/groovy-script/mods/aether_legacy/freezer.md
@@ -31,6 +31,12 @@ mods.aether.Freezer
     mods.aether_legacy.freezer.add(ItemStack, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer.add(AetherFreezable)
+    ```
+
 
 ### Recipe Builder
 
@@ -81,6 +87,24 @@ mods.aether_legacy.freezer.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer.remove(AetherFreezable)
+    ```
 
 - Removes all recipes that match the given output:
 

--- a/docs/groovy-script/mods/aether_legacy/freezer_fuel.md
+++ b/docs/groovy-script/mods/aether_legacy/freezer_fuel.md
@@ -35,6 +35,12 @@ mods.aether.FreezerFuel
     mods.aether_legacy.freezer_fuel.add(ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer_fuel.add(AetherFreezableFuel)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.aether_legacy.freezer_fuel.add(item('minecraft:packed_ice'), 1000)
@@ -43,6 +49,24 @@ mods.aether_legacy.freezer_fuel.add(item('minecraft:packed_ice'), 1000)
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer_fuel.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer_fuel.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.aether_legacy.freezer_fuel.remove(AetherFreezableFuel)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/arcaneworld/ritual.md
+++ b/docs/groovy-script/mods/arcaneworld/ritual.md
@@ -23,6 +23,13 @@ mods.arcaneworld.Ritual
 
 ## Adding Recipes
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.arcaneworld.ritual.add(Ritual)
+    ```
+
+
 ### Recipe Builder
 
 Just like other recipe types, the Ritual also uses a recipe builder.
@@ -698,6 +705,24 @@ mods.arcaneworld.ritual.recipeBuilderWeather()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.arcaneworld.ritual.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.arcaneworld.ritual.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.arcaneworld.ritual.remove(Ritual)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/atum/kiln.md
+++ b/docs/groovy-script/mods/atum/kiln.md
@@ -23,6 +23,13 @@ mods.atum.Kiln
 
 ## Adding Recipes
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.atum.kiln.add(IKilnRecipe)
+    ```
+
+
 ### Recipe Builder
 
 Just like other recipe types, the Kiln also uses a recipe builder.
@@ -84,6 +91,24 @@ mods.atum.kiln.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.atum.kiln.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.atum.kiln.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.atum.kiln.remove(IKilnRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/atum/quern.md
+++ b/docs/groovy-script/mods/atum/quern.md
@@ -23,6 +23,13 @@ mods.atum.Quern
 
 ## Adding Recipes
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.atum.quern.add(IQuernRecipe)
+    ```
+
+
 ### Recipe Builder
 
 Just like other recipe types, the Quern also uses a recipe builder.
@@ -85,6 +92,24 @@ mods.atum.quern.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.atum.quern.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.atum.quern.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.atum.quern.remove(IQuernRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/atum/spinning_wheel.md
+++ b/docs/groovy-script/mods/atum/spinning_wheel.md
@@ -25,6 +25,13 @@ mods.atum.SpinningWheel
 
 ## Adding Recipes
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.atum.spinning_wheel.add(ISpinningWheelRecipe)
+    ```
+
+
 ### Recipe Builder
 
 Just like other recipe types, the Spinning Wheel also uses a recipe builder.
@@ -87,6 +94,24 @@ mods.atum.spinning_wheel.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.atum.spinning_wheel.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.atum.spinning_wheel.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.atum.spinning_wheel.remove(ISpinningWheelRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/industrialforegoing/straw.md
+++ b/docs/groovy-script/mods/industrialforegoing/straw.md
@@ -35,6 +35,12 @@ mods.industrialforegoing.Straw
     mods.industrialforegoing.straw.add(String, FluidStack, Collection<PotionEffect>)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.industrialforegoing.straw.add(StrawHandler)
+    ```
+
 
 ### Recipe Builder
 
@@ -85,6 +91,24 @@ mods.industrialforegoing.straw.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.industrialforegoing.straw.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.industrialforegoing.straw.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.industrialforegoing.straw.remove(StrawHandler)
+    ```
 
 - Removes all registered recipes:
 

--- a/docs/groovy-script/mods/pyrotech/anvil.md
+++ b/docs/groovy-script/mods/pyrotech/anvil.md
@@ -29,6 +29,12 @@ mods.pyrotech.Anvil
     mods.pyrotech.anvil.add(String, IIngredient, ItemStack, int, String, String)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.anvil.add(AnvilRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.anvil.add('iron_to_clay', ore('ingotIron'), item('minecraft:clay_ball'), 9, 'granite', 'hammer')
@@ -130,6 +136,24 @@ mods.pyrotech.anvil.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.anvil.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.anvil.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.anvil.remove(AnvilRecipe)
+    ```
 
 - Removes all recipes that match the given output:
 

--- a/docs/groovy-script/mods/pyrotech/barrel.md
+++ b/docs/groovy-script/mods/pyrotech/barrel.md
@@ -29,6 +29,12 @@ mods.pyrotech.Barrel
     mods.pyrotech.barrel.add(String, IIngredient, IIngredient, IIngredient, IIngredient, FluidStack, FluidStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.barrel.add(BarrelRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.barrel.add('iron_dirt_water_to_lava', ore('ingotIron'), ore('ingotIron'), item('minecraft:dirt'), item('minecraft:dirt'), fluid('water'), fluid('lava'), 1000)
@@ -102,6 +108,24 @@ mods.pyrotech.barrel.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.barrel.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.barrel.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.barrel.remove(BarrelRecipe)
+    ```
 
 - Removes all recipes that match the given output:
 

--- a/docs/groovy-script/mods/pyrotech/brick_kiln.md
+++ b/docs/groovy-script/mods/pyrotech/brick_kiln.md
@@ -31,6 +31,12 @@ mods.pyrotech.BrickKiln
     mods.pyrotech.brick_kiln.add(String, IIngredient, ItemStack, int, float, ItemStack...)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_kiln.add(BrickKilnRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.brick_kiln.add('clay_to_iron_brick', item('minecraft:clay_ball') * 5, item('minecraft:iron_ingot'), 1200, 0.5f, item('minecraft:dirt'), item('minecraft:cobblestone'))
@@ -111,6 +117,24 @@ mods.pyrotech.brick_kiln.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_kiln.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_kiln.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_kiln.remove(BrickKilnRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/brick_oven.md
+++ b/docs/groovy-script/mods/pyrotech/brick_oven.md
@@ -35,6 +35,12 @@ mods.pyrotech.BrickOven
     mods.pyrotech.brick_oven.add(String, IIngredient, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_oven.add(BrickOvenRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.brick_oven.add('apple_to_dirt_brick', item('minecraft:apple'), item('minecraft:dirt'), 1000)
@@ -99,6 +105,24 @@ mods.pyrotech.brick_oven.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_oven.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_oven.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.brick_oven.remove(BrickOvenRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/campfire.md
+++ b/docs/groovy-script/mods/pyrotech/campfire.md
@@ -29,6 +29,12 @@ mods.pyrotech.Campfire
     mods.pyrotech.campfire.add(String, IIngredient, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.campfire.add(CampfireRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.campfire.add('apple_to_dirt', item('minecraft:apple'), item('minecraft:dirt'), 1000)
@@ -93,6 +99,24 @@ mods.pyrotech.campfire.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.campfire.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.campfire.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.campfire.remove(CampfireRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/chopping_block.md
+++ b/docs/groovy-script/mods/pyrotech/chopping_block.md
@@ -25,6 +25,13 @@ mods.pyrotech.ChoppingBlock
 
 ## Adding Recipes
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.chopping_block.add(ChoppingBlockRecipe)
+    ```
+
+
 ### Recipe Builder
 
 Just like other recipe types, the Chopping Block also uses a recipe builder.
@@ -91,6 +98,24 @@ mods.pyrotech.chopping_block.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.chopping_block.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.chopping_block.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.chopping_block.remove(ChoppingBlockRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/compacting_bin.md
+++ b/docs/groovy-script/mods/pyrotech/compacting_bin.md
@@ -31,6 +31,12 @@ mods.pyrotech.CompactingBin
     mods.pyrotech.compacting_bin.add(String, IIngredient, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compacting_bin.add(CompactingBinRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.compacting_bin.add('iron_to_clay', ore('ingotIron') * 5, item('minecraft:clay_ball') * 20, 9)
@@ -95,6 +101,24 @@ mods.pyrotech.compacting_bin.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compacting_bin.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compacting_bin.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compacting_bin.remove(CompactingBinRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/compost_bin.md
+++ b/docs/groovy-script/mods/pyrotech/compost_bin.md
@@ -31,6 +31,12 @@ mods.pyrotech.CompostBin
     mods.pyrotech.compost_bin.add(String, IIngredient, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compost_bin.add(CompostBinRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.compost_bin.add('iron_to_clay2', ore('ingotIron') * 5, item('minecraft:clay_ball') * 20, 2)
@@ -95,6 +101,24 @@ mods.pyrotech.compost_bin.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compost_bin.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compost_bin.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.compost_bin.remove(CompostBinRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/crude_drying_rack.md
+++ b/docs/groovy-script/mods/pyrotech/crude_drying_rack.md
@@ -31,6 +31,12 @@ mods.pyrotech.CrudeDryingRack
     mods.pyrotech.crude_drying_rack.add(String, IIngredient, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.crude_drying_rack.add(CrudeDryingRackRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.crude_drying_rack.add('apple_to_dirt', item('minecraft:apple'), item('minecraft:dirt'), 1200)
@@ -95,6 +101,24 @@ mods.pyrotech.crude_drying_rack.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.crude_drying_rack.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.crude_drying_rack.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.crude_drying_rack.remove(CrudeDryingRackRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/drying_rack.md
+++ b/docs/groovy-script/mods/pyrotech/drying_rack.md
@@ -31,6 +31,12 @@ mods.pyrotech.DryingRack
     mods.pyrotech.drying_rack.add(String, IIngredient, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.drying_rack.add(DryingRackRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.drying_rack.add('apple_to_dirt', item('minecraft:apple'), item('minecraft:dirt'), 1200)
@@ -95,6 +101,24 @@ mods.pyrotech.drying_rack.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.drying_rack.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.drying_rack.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.drying_rack.remove(DryingRackRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/pit_kiln.md
+++ b/docs/groovy-script/mods/pyrotech/pit_kiln.md
@@ -33,6 +33,12 @@ mods.pyrotech.Kiln
     mods.pyrotech.pit_kiln.add(String, IIngredient, ItemStack, int, float, Iterable<ItemStack>)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.pit_kiln.add(KilnPitRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.pit_kiln.add('clay_to_iron', item('minecraft:clay_ball') * 5, item('minecraft:iron_ingot'), 1200, 0.5f, [item('minecraft:dirt'), item('minecraft:cobblestone')])
@@ -113,6 +119,24 @@ mods.pyrotech.pit_kiln.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.pit_kiln.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.pit_kiln.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.pit_kiln.remove(KilnPitRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/soaking_pot.md
+++ b/docs/groovy-script/mods/pyrotech/soaking_pot.md
@@ -31,6 +31,12 @@ mods.pyrotech.SoakingPot
     mods.pyrotech.soaking_pot.add(String, IIngredient, FluidStack, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.soaking_pot.add(SoakingPotRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.soaking_pot.add('dirt_to_apple', item('minecraft:dirt'), fluid('water'), item('minecraft:apple'), 1200)
@@ -111,6 +117,24 @@ mods.pyrotech.soaking_pot.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.soaking_pot.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.soaking_pot.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.soaking_pot.remove(SoakingPotRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/stone_kiln.md
+++ b/docs/groovy-script/mods/pyrotech/stone_kiln.md
@@ -31,6 +31,12 @@ mods.pyrotech.StoneKiln
     mods.pyrotech.stone_kiln.add(String, IIngredient, ItemStack, int, float, ItemStack...)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_kiln.add(StoneKilnRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.stone_kiln.add('clay_to_iron_stone', item('minecraft:clay_ball') * 5, item('minecraft:iron_ingot'), 1200, 0.5f, item('minecraft:dirt'), item('minecraft:cobblestone'))
@@ -111,6 +117,24 @@ mods.pyrotech.stone_kiln.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_kiln.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_kiln.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_kiln.remove(StoneKilnRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/stone_oven.md
+++ b/docs/groovy-script/mods/pyrotech/stone_oven.md
@@ -35,6 +35,12 @@ mods.pyrotech.StoneOven
     mods.pyrotech.stone_oven.add(String, IIngredient, ItemStack, int)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_oven.add(StoneOvenRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.stone_oven.add('apple_to_dirt_stone', item('minecraft:apple'), item('minecraft:dirt'), 1000)
@@ -99,6 +105,24 @@ mods.pyrotech.stone_oven.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_oven.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_oven.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.stone_oven.remove(StoneOvenRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 

--- a/docs/groovy-script/mods/pyrotech/tanning_rack.md
+++ b/docs/groovy-script/mods/pyrotech/tanning_rack.md
@@ -31,6 +31,12 @@ mods.pyrotech.TanningRack
     mods.pyrotech.tanning_rack.add(String, IIngredient, ItemStack, int, ItemStack)
     ```
 
+- Adds the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.tanning_rack.add(TanningRackRecipe)
+    ```
+
 :::::::::: details Example {open id="example"}
 ```groovy:no-line-numbers
 mods.pyrotech.tanning_rack.add('apple_to_dirt', item('minecraft:apple'), item('minecraft:dirt'), 1200, item('minecraft:clay_ball'))
@@ -101,6 +107,24 @@ mods.pyrotech.tanning_rack.recipeBuilder()
 ::::::::::
 
 ## Removing Recipes
+
+- Removes the recipe with the given Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.tanning_rack.remove(ResourceLocation)
+    ```
+
+- Removes the recipe with the given String as its Resource Location:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.tanning_rack.remove(String)
+    ```
+
+- Removes the recipe:
+
+    ```groovy:no-line-numbers
+    mods.pyrotech.tanning_rack.remove(TanningRackRecipe)
+    ```
 
 - Removes all recipes that match the given input:
 


### PR DESCRIPTION
changes in this PR:
- update documentation of vanilla registries to be generated via https://github.com/CleanroomMC/GroovyScript/pull/300.
	- new: `command`, `gameRule`.
	- updated: `crafting`, `furnace`, `oreDict`, `player`, `rarity`.
		- `crafting` now indicates that it can be removed by ResourceLocation.
	- rename the index from `Helpers` to `Registries` to hopefully make it more visible.
	- minor adjustments made to ensure correctness due to lacking generation based on global bindings for aliases.
- update documentation for  `atum`, `aether legacy`, `pyrotech`, and `industrial foregoing` to match the new `ForgeRegistryWrapper` doc annotations.
- add a number file names to different codeblocks.
- improve wording in `groovy_modifications.md`.
- fix incorrect code examples in `differences_from_java.md`, where the java code was incorrect. also update the map example to highlight more alternatives.
- add a handful of ways to count loops in `loops.md`
- add a warning to `maps.md` relating to the key being a method requiring being wrapped in parentheses to function properly.

i was rather surprised that some of these changes were in here, as i had meant to open a separate PR for them. simply forgot to switch branches.